### PR TITLE
Add Parsing list item.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome F# frameworks, libraries, software and resources.
   - [Logging](#logging)
   - [Package Management](#package-management)
   - [Serialization](#serialization)
+  - [Parsing](#parsing)
   - [Testing](#testing)
   - [Web frameworks](#web-frameworks)
   - [.Net Core Templates](#net-core-templates)
@@ -145,6 +146,10 @@ A curated list of awesome F# frameworks, libraries, software and resources.
 ## Serialization
 
 * [FsPickler ★ 195 ⧗ 13](https://github.com/mbraceproject/FsPickler) - Fast, multi-format messaging serializer for .NET. [MIT]
+
+## Parsing
+
+* [FParsec ★ 50 ⧗ 0](https://github.com/stephan-tolksdorf/fparsec) - FParsec is a parser combinator library for F#. [BSD 2](http://www.quanttec.com/fparsec/license.html)
 
 ## Testing
 


### PR DESCRIPTION
Add FParsec
Should add FsAttoparsec with next pull request
* [FsAttoparsec ★ 23 ⧗ 0](https://github.com/pocketberserker/FsAttoparsec) - A fast F# parser combinator library, aimed particularly at dealing efficiently with network protocols and complicated text/binary file formats. [BSD 3](https://github.com/pocketberserker/FsAttoparsec/blob/master/LICENSE)