### PR TITLE
Remove linking to tag on ploeh blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ A curated list of awesome F# frameworks, libraries, software and resources.
 * [Dave Thomas Blog](http://7sharpnine.com/)
 * [Don Syme's WebLog on F# and Related Topics](https://blogs.msdn.microsoft.com/dsyme/)
 * [Krzysztof Cieslak's Blog](http://kcieslak.io/)
-* [Mark Seemann's Blog](http://blog.ploeh.dk/tags/#F#-ref)
+* [Mark Seemann's Blog](http://blog.ploeh.dk/)
 * [Sergey Tihon's Blog](https://sergeytihon.wordpress.com/)
 * [Tomas Petricek's Blog](http://tomasp.net/blog/)
 


### PR DESCRIPTION
Even non-tagged things could be related to F# somehow and even if it would be changed in the future, people can figure out how to filter by tag. This chapter is not about posts, it's about blogs.