### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ A curated list of awesome F# frameworks, libraries, software and resources.
 * [Fleece ★ 94 ⧗ 76](https://github.com/mausch/Fleece) - Fleece is a JSON mapper for F#. It simplifies mapping from a Json library's JsonValue onto your types, and mapping from your types onto JsonValue. [Apache-2.0]
 * [FsPickler ★ 195 ⧗ 13](https://github.com/mbraceproject/FsPickler) - Fast, multi-format messaging serializer for .NET. [MIT]
 * [Legivel ★ 19 ⧗ 4](https://github.com/fjoppe/Legivel) - F# Yaml 1.2 parser. [Unlicense]
-* [Thoth.Json ★ 40 ⧗ 11](https://mangelmaxime.github.io/Thoth/) - Json encoder/decoder library inspire by Elm. [MIT]
+* [Thoth.Json ★ 40 ⧗ 11](https://thoth-org.github.io/Thoth.Json/) - Json encoder/decoder library inspire by Elm. [MIT]
 
 ## Search
 * [FlexSearch ★ 133 ⧗ 14](https://github.com/flexsearch/flexsearch) - high performance REST/SOAP services based full-text searching platform built on top of the popular Lucene search library. [Apache 2.0]


### PR DESCRIPTION
It looks like the link for Thoth.Json changed at some point. Here is an updated link.