### PR TITLE
Change link to Fabulous

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Looking to have a more enjoyable experience when consuming a popular .NET librar
 [MSTest](https://github.com/microsoft/testfx)/[NUnit](https://github.com/nunit/nunit)/[xUnit.net](https://github.com/xunit/xunit) | [FsUnit](https://github.com/fsprojects/FsUnit)
 [System.Text.Json](https://github.com/dotnet/runtime/tree/main/src/libraries/System.Text.Json) | [FSharp.SystemTextJson](https://github.com/Tarmil/FSharp.SystemTextJson)
 [WPF](https://github.com/dotnet/wpf) | [Elmish.WPF](https://github.com/elmish/Elmish.WPF)
-[Xamarin.Forms](https://github.com/xamarin/Xamarin.Forms) | [Fabulous](https://fsprojects.github.io/Fabulous/)
+[Xamarin.Forms](https://github.com/xamarin/Xamarin.Forms) | [Fabulous](https://github.com/fabulous-dev/Fabulous)
 
 ## Actor frameworks
 
@@ -183,7 +183,7 @@ Looking to have a more enjoyable experience when consuming a popular .NET librar
 
 * [Avalonia.FuncUI](https://github.com/fsprojects/Avalonia.FuncUI) - Develop cross-platform MVU GUI Applications using F# and Avalonia
 * [Epoxy](https://github.com/kekyo/epoxy) - An independent flexible XAML MVVM library for .NET
-* [Fabulous](https://fsprojects.github.io/Fabulous/) - F# Functional App Development, using declarative dynamic UI
+* [Fabulous](https://github.com/fabulous-dev/Fabulous) - F# Functional App Development, using declarative dynamic UI
 
 ## HTTP Clients
 * [Http.fs](https://github.com/haf/Http.fs) - A simple, functional HTTP client library for F#


### PR DESCRIPTION
The current link for Fabuous, https://fsprojects.github.io/Fabulous/ is returning 404.

