### PR TITLE
Felicity: roll back my erroneous change

### DIFF
--- a/ARCHIVE.md
+++ b/ARCHIVE.md
@@ -15,6 +15,9 @@ This is a storage of links that were removed from the main list.
 ## Compilers for Other Platforms
 - [Pengines.Client](https://github.com/ninjarobot/Pengines.Client) - Sandboxed Prolog environment.
 
+## Courses
+- [F# workshop](http://www.fsharpworkshop.com/)
+
 ## Development Tools
 
 ### Editor Plugins

--- a/README.md
+++ b/README.md
@@ -380,5 +380,4 @@ Looking to have a more enjoyable experience when consuming a popular .NET librar
 
 ### Courses
 
-- [F# workshop](http://www.fsharpworkshop.com/)
 - [Write yourself a scheme in 48 hours using F#](https://write-yourself-a-scheme.pangwa.com/)

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Looking to have a more enjoyable experience when consuming a popular .NET librar
 <!--lint disable double-link -->
 - [Bolero](https://github.com/fsbolero/Bolero/) - F# in WebAssembly, develop SPAs with the full power of F# and .NET Blazor.
 - [Falco](https://github.com/pimbrouwers/Falco/) - A functional-first toolkit for building brilliant ASP.NET Core applications using F#.
-- [Felicity](https://github.com/cmeeren/Felicity) - Boilerplate-free, idiomatic JSON API for your beautiful, idiomatic F# domain model.
+- [Felicity](https://github.com/cmeeren/Felicity) - Boilerplate-free, idiomatic JSON:API for your beautiful, idiomatic F# domain model.
 - [Feliz](https://github.com/Zaid-Ajaj/Feliz) - A fresh retake of the React API in Fable and a collection of high-quality components to build React applications in F#.
 - [Genit](https://github.com/lefthandedgoat/genit) - Cross-platform website generator and server using F#, Suave and PostgreSQL or MS SQL Server.
 - [Giraffe](https://github.com/giraffe-fsharp/Giraffe) - Native functional ASP.NET Core web framework for F# developers.


### PR DESCRIPTION
I was incorrect in my cleaning up of formatting. Sorry, didn't know that [JSON:API](https://jsonapi.org/) is a very specific thing.

This is now restored.